### PR TITLE
fix: Remove all files from Composer files autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,7 @@
         "vlucas/phpdotenv": "^5.5"
     },
     "autoload": {
-        "files": [
-            "config.php"
-        ]
+        "files": []
     },
     "config": {
         "vendor-dir": "vendor"


### PR DESCRIPTION
The `config.php` and `functions.php` files were being loaded twice: once by the Composer `files` autoloader and again by explicit `require_once` calls in application scripts. This caused `Cannot redeclare function` fatal errors.

This commit resolves the issue by removing all files from the `autoload.files` array in `composer.json`. The application scripts are already responsible for including these files explicitly, so the autoload entries were redundant and causing conflicts. This makes the dependency chain clear and prevents redeclaration errors.